### PR TITLE
patch: Update example user docs URL in docs (#31)

### DIFF
--- a/docs/modules/add-to-charm/pages/user-docs-url.adoc
+++ b/docs/modules/add-to-charm/pages/user-docs-url.adoc
@@ -61,11 +61,11 @@ charmhub.io:
     /{ex-charm}/docs/refresh/{ex-track}/: # <.>
       backend-inter-time: 5s
       cache-validity: '200 307 1h'
-      extra-config: ['return 307 https://canonical-charmed-{ex-charm}.readthedocs-hosted.com/{ex-track}/how-to/refresh/'] # <.>
+      extra-config: ['return 307 https://canonical.com/data/{ex-charm-vm}/docs/{ex-track}/how-to/refresh/'] # <.>
 ----
 <.> Replace `{ex-charm}` with the charm name in metadata.yaml.
 Replace `{ex-track}` with xref:charm-version.adoc#workflow[the track the charm is released to]
-<.> Replace `https://canonical-charmed-{ex-charm}.readthedocs-hosted.com/{ex-track}/how-to/refresh/` with the <<target>>
+<.> Replace `https://canonical.com/data/{ex-charm-vm}/docs/{ex-track}/how-to/refresh/` with the <<target>>
 
 NOTE: Use a https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/307[307 HTTP response status code] to indicate a temporary redirect so that the redirect target can be changed in the future (if versions in the same track need different refresh instructions)
 --


### PR DESCRIPTION
https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/16/how-to/refresh/ (used as example) was migrated to
https://canonical.com/data/postgresql/docs/16/how-to/refresh/; update example

(cherry picked from commit 164ae38ceea999931f52f91039ab5c2bda0af6e7)